### PR TITLE
fixed bug of diff_joint masking

### DIFF
--- a/seed_r7_robot_interface/include/stroke_converter.h
+++ b/seed_r7_robot_interface/include/stroke_converter.h
@@ -41,6 +41,7 @@ public:
   void makeInvTable(std::vector<StrokeMap>& _inv_table,std::vector<StrokeMap>& _table);
   float setAngleToStroke (float _angle, std::vector<StrokeMap>& _table);
   float setStrokeToAngle (float _stroke, std::vector<StrokeMap>& _inv_table);
+  std::vector<std::pair<bool,int>> diff_joint_;
 
   DiffJoint setDualAngleToStroke (float _r_angle, float _p_angle,
       std::vector<StrokeMap>& _r_table, std::vector<StrokeMap>& _p_table, std::string _diff_axis="roll");

--- a/seed_r7_robot_interface/src/stroke_converter.cpp
+++ b/seed_r7_robot_interface/src/stroke_converter.cpp
@@ -20,6 +20,26 @@ StrokeConverter::StrokeConverter(ros::NodeHandle _nh, std::string _robot_model) 
 
   ROS_INFO("finish to make stroke convert table");
 
+  //set diff joint
+  diff_joint_.resize(30);  //this number is fixed array size of aero API
+  fill(diff_joint_.begin(),diff_joint_.end(),std::make_pair(false,0));
+  if(robot_model_ == "typeF"){
+    //waist
+    diff_joint_.at(1) = std::make_pair(true,2);
+    diff_joint_.at(2) = std::make_pair(true,1);
+    //left wrist
+    diff_joint_.at(8) = std::make_pair(true,9);
+    diff_joint_.at(9) = std::make_pair(true,8);
+    //neck
+    diff_joint_.at(15) = std::make_pair(true,16);
+    diff_joint_.at(16) = std::make_pair(true,15);
+    //right wrist
+    diff_joint_.at(22) = std::make_pair(true,23);
+    diff_joint_.at(23) = std::make_pair(true,22);
+  }
+  else{
+    ROS_ERROR("not supported %s in stroke_converter.cpp", robot_model_.c_str());
+  }
 }
 
 StrokeConverter::~StrokeConverter()

--- a/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
@@ -278,7 +278,10 @@ namespace robot_hardware
     // masking
     std::vector<int16_t> snt_strokes(ref_strokes);
     for(size_t i = 0; i < ref_strokes.size() ; ++i){
-      if(!mask_positions[i]) snt_strokes[i] = 0x7FFF;
+      if(stroke_converter_->diff_joint_.at(i).first == true){
+        if(!mask_positions[i] && !mask_positions[stroke_converter_->diff_joint_.at(i).second]) snt_strokes[i] = 0x7FFF;
+      }
+      else if(!mask_positions[i]) snt_strokes[i] = 0x7FFF;
     }
 
     // split strokes into upper and lower


### PR DESCRIPTION
below bug was fixed:

* when a position command is sent to differential joints, sometimes only one axis is masked as 0x7FFF

@hi-kondo 
please check with another robot type