### PR TITLE
- add smach_viewer to demo.lauch

### DIFF
--- a/seed_r7_samples/launch/demo.launch
+++ b/seed_r7_samples/launch/demo.launch
@@ -17,7 +17,8 @@
   <include file="$(find seed_r7_moveit_config)/../seed_r7_$(arg robot_model)_moveit_config/launch/move_group.launch" />
 
   <!-- demo program -->
-  <node pkg="seed_r7_samples" name="scenario_node" type="demo.py" output="screen" if="$(arg run_demo)"/>
+  <node pkg="seed_r7_samples" name="scenario_node" type="demo.py" output="screen" if="$(arg run_demo)"
+        launch-prefix="xterm -e" />
 
   <!-- RViz -->
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find seed_r7_samples)/rviz.rviz" required="true" />

--- a/seed_r7_samples/launch/demo.launch
+++ b/seed_r7_samples/launch/demo.launch
@@ -22,5 +22,7 @@
 
   <!-- RViz -->
 	<node name="rviz" pkg="rviz" type="rviz" args="-d $(find seed_r7_samples)/rviz.rviz" required="true" />
+   <!-- smach_viewer -->
+   <node name="smach_viewer" pkg="smach_viewer" type="smach_viewer.py" />
 
 </launch>


### PR DESCRIPTION
this falls on melodic
```
[ INFO] [1574397043.213141873]: max: 30.572131 [ms], ave: 20.217767 [ms]
usage: smach_viewer.py [-h] [-f]
smach_viewer.py: error: unrecognized arguments: __name:=smach_viewer __log:=/home/k-okada/.ros/log/d53ecebc-0ce0-11ea-8f05-00bb605aa0af/smach_viewer-13.log
[smach_viewer-13] process has died [pid 14946, exit code 2, cmd /home/k-okada/catkin_ws/seed_ws/src/executive_smach_visualization/smach_viewer/scripts/smach_viewer.py __name:=smach_viewer __log:=/home/k-okada/.ros/log/d53ecebc-0ce0-11ea-8f05-00bb605aa0af/smach_viewer-13.log].
log file: /home/k-okada/.ros/log/d53ecebc-0ce0-11ea-8f05-00bb605aa0af/smach_viewer-13*.log

```
c.f. https://github.com/ros-visualization/executive_smach_visualization/issues/20#issuecomment-445437984