### PR TITLE
add more install target

### DIFF
--- a/seed_r7_robot_interface/CMakeLists.txt
+++ b/seed_r7_robot_interface/CMakeLists.txt
@@ -33,7 +33,6 @@ target_link_libraries(${PROJECT_NAME}_typeF ${catkin_LIBRARIES})
 install(
   DIRECTORY typef
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-  PATTERN src  EXCLUDE
 )
 
 # Install

--- a/seed_r7_samples/CMakeLists.txt
+++ b/seed_r7_samples/CMakeLists.txt
@@ -5,6 +5,11 @@ find_package(catkin REQUIRED)
 
 catkin_package()
 
-install(DIRECTORY launch scripts
+install(DIRECTORY launch scripts config
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+	  USE_SOURCE_PERMISSIONS
+ )
+
+install(FILES rviz.rviz
           DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
  )


### PR DESCRIPTION
- install config/ directory and rviz.rviz file
-  'PATTERN src  EXCLUDE' only installs files under src/ direcotry, so remove  this line