### PR TITLE
fix travis tset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: true
 dist: trusty
 language: python
 python:
-  - "3.4"
+  - "3.5"
 env:
   global:
     - JOB_PATH=/tmp/devel_job

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 seed-noid meta package
 
 ## Continuous Integration Status
+service    | Master  |
+---------- | ------- |
+Travis     | [![Build Status](https://travis-ci.com/seed-solutions/seed_r7_ros_pkg.svg?branch=master)](https://travis-ci.com/seed-solutions/seed_r7_ros_pkg/) |
+
 service    | Kinetic | Melodic |
 ---------- | ------- | ------- |
-Travis     | ![Build Status](https://travis-ci.com/seed-solutions/seed_r7_ros_pkg.svg?branch=master) | ![Build Status](https://travis-ci.com/seed-solutions/seed_r7_ros_pkg.svg?branch=master)
+ROS Buildfarm     | [![Build Status](http://build.ros.org/job/Kbin_uX64__seed_r7_ros_pkg__ubuntu_xenial_amd64__binary/badge/icon)](http://build.ros.org/job/Kbin_uX64__seed_r7_ros_pkg__ubuntu_xenial_amd64__binary/) | [![Build Status](http://build.ros.org/job/Mbin_uB64__seed_r7_ros_pkg__ubuntu_bionic_amd64__binary/badge/icon)](http://build.ros.org/job/Mbin_uB64__seed_r7_ros_pkg__ubuntu_bionic_amd64__binary/) |
 ## How to install
 ### 1. From Debian
 ```


### PR DESCRIPTION
- fix travis/rosbuildfarm budge
- fix travsi errors

   ros_buildfarm on melodic requires python >= 3.5 (see  https://github.com/tork-a/cis_camera/pull/27)