### PR TITLE
Add robot status pub

### DIFF
--- a/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_lower_controller.h
+++ b/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_lower_controller.h
@@ -24,6 +24,7 @@ class LowerController
     float getBatteryVoltage();
     std::string getFirmwareVersion();
     void getRobotStatus(int8_t _number);
+    void checkRobotStatus();
 
     bool is_open_;
     std::vector<int16_t> raw_data_;
@@ -37,9 +38,40 @@ class LowerController
     std::vector<int> wheel_aero_index_;
     std::vector<std::pair<int,std::string>> wheel_table_;
 
+    bool comm_err_;
+    struct RobotStatus {
+      bool connection_err_;
+      bool calib_err_;
+      bool motor_err_;
+      bool temp_err_;
+      bool res_err_;
+      bool step_out_err_;
+      bool p_stopped_err_;
+      bool power_err_;
+    } robot_status_;
+
   protected:
     aero::controller::AeroCommand *lower_;
-    const static uint32_t BAUDRATE = 1000000;   
+    const static uint32_t BAUDRATE = 1000000;
+
+    enum error_bit_t{
+      can2_connection = 0,
+      can2_calibration = 1,
+      can2_motor_status = 2,
+      can2_temperature = 3,
+      can2_response = 4,
+      can2_step_out = 5,
+      can2_protective_stopped = 6,
+      can2_power = 7,
+      can1_connection = 8,
+      can1_calibration = 9,
+      can1_motor_status = 10,
+      can1_temperature = 11,
+      can1_response = 12,
+      can1_step_out = 13,
+      can1_protective_stopped = 14,
+      can1_power = 15,
+    };
 };
 
 }

--- a/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_robot_hardware.h
+++ b/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_robot_hardware.h
@@ -61,6 +61,9 @@
 
 #include <mutex>
 
+//for robot status view
+#include <std_msgs/String.h>
+#include <diagnostic_updater/diagnostic_updater.h>
 
 namespace robot_hardware
 {
@@ -88,10 +91,20 @@ public:
   void getBatteryVoltage(const ros::TimerEvent& _event);
   void runLedScript(uint8_t _number, uint16_t _script);
   void setRobotStatus();
+  void setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat);
   //----------------------
 
-  //Robot Status
-  bool is_protective_stopped_;
+  bool comm_err_;
+  struct RobotStatus {
+      bool connection_err_;
+      bool calib_err_;
+      bool motor_err_;
+      bool temp_err_;
+      bool res_err_;
+      bool step_out_err_;
+      bool p_stopped_err_;
+      bool power_err_;
+    } robot_status_;
 
 private:
   ros::ServiceServer reset_robot_status_server_;
@@ -147,6 +160,9 @@ protected:
 
   pluginlib::ClassLoader<seed_converter::StrokeConverter> converter_loader_;
   boost::shared_ptr<seed_converter::StrokeConverter> stroke_converter_;
+
+  //for robot status view
+  diagnostic_updater::Updater diagnostic_updater_;
 };
 
 }

--- a/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_upper_controller.h
+++ b/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_upper_controller.h
@@ -21,6 +21,7 @@ class UpperController
     void setCurrent(uint8_t _number, uint8_t _max, uint8_t _down);
     void runScript(uint8_t _number, uint16_t _script);
     std::string getFirmwareVersion();
+    void checkRobotStatus();
 
     bool is_open_;
     std::vector<int16_t> raw_data_;
@@ -29,9 +30,40 @@ class UpperController
     std::vector<int> aero_index_;
     std::vector<std::pair<int,std::string>> aero_table_;
 
-  protected: 
+    bool comm_err_;
+    struct RobotStatus {
+      bool connection_err_;
+      bool calib_err_;
+      bool motor_err_;
+      bool temp_err_;
+      bool res_err_;
+      bool step_out_err_;
+      bool p_stopped_err_;
+      bool power_err_;
+    } robot_status_;
+
+  protected:
     aero::controller::AeroCommand *upper_;
-    const static uint32_t BAUDRATE = 1000000;      
+    const static uint32_t BAUDRATE = 1000000;
+
+    enum error_bit_t{
+      can2_connection = 0,
+      can2_calibration = 1,
+      can2_motor_status = 2,
+      can2_temperature = 3,
+      can2_response = 4,
+      can2_step_out = 5,
+      can2_protective_stopped = 6,
+      can2_power = 7,
+      can1_connection = 8,
+      can1_calibration = 9,
+      can1_motor_status = 10,
+      can1_temperature = 11,
+      can1_response = 12,
+      can1_step_out = 13,
+      can1_protective_stopped = 14,
+      can1_power = 15,
+    };
 };
 
 }

--- a/seed_r7_ros_controller/src/seed_r7_lower_controller.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_lower_controller.cpp
@@ -38,7 +38,7 @@ robot_hardware::LowerController::LowerController(const std::string& _port)
  for(size_t i = 0; i < wheel_table_.size() ; ++i){
     size_t index = std::distance(wheel_aero_index_.begin(), std::find(wheel_aero_index_.begin(),wheel_aero_index_.end(),i));
     if(index != wheel_aero_index_.size()) wheel_table_.at(i) = std::make_pair(index,wheel_name_.at(index));
-  } 
+  }
 }
 
 robot_hardware::LowerController::~LowerController()
@@ -50,6 +50,7 @@ void robot_hardware::LowerController::getPosition()
 {
   if(is_open_) raw_data_ = lower_->getPosition(0);
 
+  checkRobotStatus();
 }
 
 void robot_hardware::LowerController::sendPosition(uint16_t _time, std::vector<int16_t>& _data)
@@ -57,6 +58,7 @@ void robot_hardware::LowerController::sendPosition(uint16_t _time, std::vector<i
   if(is_open_) raw_data_ = lower_->actuateByPosition(_time, _data.data());
   else raw_data_.assign(_data.begin(), _data.end());
 
+  checkRobotStatus();
 }
 
 void robot_hardware::LowerController::remapAeroToRos
@@ -123,4 +125,38 @@ void robot_hardware::LowerController::getRobotStatus(int8_t _number)
   if(is_open_)lower_->getStatus(_number);
 
   //_number == 0xFF : reset flag
+}
+
+void robot_hardware::LowerController::checkRobotStatus()
+{
+  if(is_open_) comm_err_ = lower_->comm_err_;
+  else comm_err_ = false;
+
+  int16_t status_bit = raw_data_.back();
+  int8_t max_bit_size = 16;
+
+  robot_status_.connection_err_ = (status_bit >> error_bit_t::can1_connection)&1 ||
+    (status_bit >> error_bit_t::can2_connection)&1;
+
+  robot_status_.calib_err_ = (status_bit >> error_bit_t::can1_calibration)&1 ||
+    (status_bit >> error_bit_t::can2_calibration)&1;
+
+  robot_status_.motor_err_ = (status_bit >> error_bit_t::can1_motor_status)&1 ||
+    (status_bit >> error_bit_t::can2_motor_status)&1;
+
+  robot_status_.temp_err_ = (status_bit >> error_bit_t::can1_temperature)&1 ||
+    (status_bit >> error_bit_t::can2_temperature)&1;
+
+  robot_status_.res_err_ = (status_bit >> error_bit_t::can1_response)&1 ||
+    (status_bit >> error_bit_t::can2_response)&1;
+
+  robot_status_.step_out_err_ = (status_bit >> error_bit_t::can1_step_out)&1 ||
+    (status_bit >> error_bit_t::can2_step_out)&1;
+
+  robot_status_.p_stopped_err_ = (status_bit >> error_bit_t::can1_protective_stopped)&1 ||
+    (status_bit >> error_bit_t::can2_protective_stopped)&1;
+
+  robot_status_.power_err_ = (status_bit >> error_bit_t::can1_power)&1 ||
+    (status_bit >> error_bit_t::can2_power)&1;
+
 }

--- a/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
@@ -68,7 +68,7 @@ void robot_hardware::MoverController::cmdVelCallback(const geometry_msgs::TwistC
   ROS_DEBUG("cmd_vel: %f %f %f", _cmd_vel->linear.x, _cmd_vel->linear.y, _cmd_vel->angular.z);
 
   if (base_mtx_.try_lock()) {
-    if(hw_->is_protective_stopped_)
+    if(hw_->robot_status_.p_stopped_err_)
     {
       //move_base_action_->cancelAllGoals();  //if you want to cancel goal, use this
       vx_ = vy_ = vth_ = 0.0;

--- a/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
@@ -424,22 +424,22 @@ namespace robot_hardware
   void RobotHW::setDiagnostics(diagnostic_updater::DiagnosticStatusWrapper& stat)
   {
     if(comm_err_ ){
-      stat.summary(2,"E-Stop switch is pushed or the USB cable is plugged out");
+      stat.summary(2,"Now calibrating, or the USB cable is plugged out");
     }
     else if(robot_status_.power_err_ ){
       stat.summary(2,"Power failed, pleae check the battery");
+    }
+    else if(robot_status_.connection_err_){
+      stat.summary(2,"Connection error occurred, please check the cable");
+    }
+    else if( robot_status_.temp_err_ ){
+      stat.summary(2,"Motor driver is high temperature, please reboot the robot");
     }
     else if(robot_status_.p_stopped_err_){
       stat.summary(2,"Protective stopped, please release it");
     }
     else if(robot_status_.calib_err_ ){
       stat.summary(2,"Calibration error occurred, please recalibration");
-    }
-    else if( robot_status_.temp_err_ ){
-      stat.summary(2,"Motor driver is high temperature, please reboot the robot");
-    }
-    else if(robot_status_.connection_err_){
-      stat.summary(2,"Connection error occurred, please check the cable");
     }
     else if(robot_status_.step_out_err_ ){
       stat.summary(1,"Step-out has occurred");
@@ -451,14 +451,19 @@ namespace robot_hardware
       stat.summary(0,"System all green");
     }
 
+    if(robot_status_.connection_err_ && robot_status_.calib_err_ ){
+      stat.summary(2,"E-Stop switch is pushed, please release it");
+    }
+
     stat.add("Communication Error", comm_err_);
+    stat.add("Emergency Stopped", robot_status_.connection_err_ && robot_status_.calib_err_ );
+    stat.add("Protective Stopped",robot_status_.p_stopped_err_);
     stat.add("Connection Error",robot_status_.connection_err_);
     stat.add("Calibration Error",robot_status_.calib_err_);
     stat.add("Motor Servo OFF",robot_status_.motor_err_);
     stat.add("Temperature Error",robot_status_.temp_err_);
     stat.add("Response Error",robot_status_.res_err_);
     stat.add("Step Out Occurred",robot_status_.step_out_err_);
-    stat.add("Protective Stopped",robot_status_.p_stopped_err_);
     stat.add("Power Failed",robot_status_.power_err_);
 
   }

--- a/seed_r7_ros_controller/src/seed_r7_upper_controller.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_upper_controller.cpp
@@ -29,7 +29,6 @@ robot_hardware::UpperController::UpperController(const std::string& _port)
     size_t index = std::distance(aero_index_.begin(), std::find(aero_index_.begin(),aero_index_.end(),i));
     if(index != aero_index_.size()) aero_table_.at(i) = std::make_pair(index,name_.at(index));
   }
-  
 }
 
 robot_hardware::UpperController::~UpperController()
@@ -40,12 +39,16 @@ robot_hardware::UpperController::~UpperController()
 void robot_hardware::UpperController::getPosition()
 {
   if(is_open_) raw_data_ = upper_->getPosition(0);
+
+  checkRobotStatus();
 }
 
 void robot_hardware::UpperController::sendPosition(uint16_t _time, std::vector<int16_t>& _data)
 {
   if(is_open_) raw_data_ = upper_->actuateByPosition(_time, _data.data());
   else raw_data_.assign(_data.begin(), _data.end());
+
+  checkRobotStatus();
 }
 
 void robot_hardware::UpperController::remapAeroToRos
@@ -81,4 +84,37 @@ std::string robot_hardware::UpperController::getFirmwareVersion()
 {
   if(is_open_) return upper_->getVersion(0);
   else return "";
+}
+
+void robot_hardware::UpperController::checkRobotStatus()
+{
+  if(is_open_) comm_err_ = upper_->comm_err_;
+  else comm_err_ = false;
+
+  int16_t status_bit = raw_data_.back();
+  int8_t max_bit_size = 16;
+
+  robot_status_.connection_err_ = (status_bit >> error_bit_t::can1_connection)&1 ||
+    (status_bit >> error_bit_t::can2_connection)&1;
+
+  robot_status_.calib_err_ = (status_bit >> error_bit_t::can1_calibration)&1 ||
+    (status_bit >> error_bit_t::can2_calibration)&1;
+
+  robot_status_.motor_err_ = (status_bit >> error_bit_t::can1_motor_status)&1 ||
+    (status_bit >> error_bit_t::can2_motor_status)&1;
+
+  robot_status_.temp_err_ = (status_bit >> error_bit_t::can1_temperature)&1 ||
+    (status_bit >> error_bit_t::can2_temperature)&1;
+
+  robot_status_.res_err_ = (status_bit >> error_bit_t::can1_response)&1 ||
+    (status_bit >> error_bit_t::can2_response)&1;
+
+  robot_status_.step_out_err_ = (status_bit >> error_bit_t::can1_step_out)&1 ||
+    (status_bit >> error_bit_t::can2_step_out)&1;
+
+  robot_status_.p_stopped_err_ = (status_bit >> error_bit_t::can1_protective_stopped)&1 ||
+    (status_bit >> error_bit_t::can2_protective_stopped)&1;
+
+  robot_status_.power_err_ = (status_bit >> error_bit_t::can1_power)&1 ||
+    (status_bit >> error_bit_t::can2_power)&1;
 }


### PR DESCRIPTION
For checking the robot state from your applications, made [diagnostics tool](http://wiki.ros.org/diagnostics) availabe.
**it can be used only SEED-Noid-typeG not typeF!**

You can check the state easily by using [runtime_monitor](http://wiki.ros.org/runtime_monitor) or [OverlayDiagnostic in jsk_visualization ](http://wiki.ros.org/jsk_visualization) like below:

<img src="https://user-images.githubusercontent.com/12426780/95843635-e1cab580-0d82-11eb-996e-9708eb13bd9d.png" width="50%">

<img src="https://user-images.githubusercontent.com/12426780/95843640-e3947900-0d82-11eb-879c-10120c285141.png" width="50%">

to subscribe ``/diagnostics`` topic, please refer below:
```Python
#!/usr/bin/env python
# -*- coding: utf-8 -*-
import rospy
from diagnostic_msgs.msg import DiagnosticArray

class SubDiagnostic():
  def __init__(self):
    pass

  def callback(self,data):
    data = data.status

    if('SEED-Noid-Mover' in data[0].hardware_id):
      for i in range(0,len(data[0].values)):
        print data[0].values[i]
        print '-------\n'
      print '-------\n'

  def main(self):
    rospy.Subscriber("/diagnostics", DiagnosticArray, self.callback)
    rospy.spin()

if __name__ == '__main__':
  rospy.init_node('sub_diagnostic_node', anonymous=True)

  sd = SubDiagnostic()

  try:
    sd.main()
  except rospy.ROSInterruptException: pass
```