### PR TITLE
change the behavior on ESTOP

### DIFF
--- a/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
@@ -68,7 +68,8 @@ void robot_hardware::MoverController::cmdVelCallback(const geometry_msgs::TwistC
   ROS_DEBUG("cmd_vel: %f %f %f", _cmd_vel->linear.x, _cmd_vel->linear.y, _cmd_vel->angular.z);
 
   if (base_mtx_.try_lock()) {
-    if(hw_->robot_status_.p_stopped_err_)
+    if(hw_->robot_status_.p_stopped_err_ ||
+      (hw_->robot_status_.connection_err_ && hw_->robot_status_.calib_err_) )
     {
       //move_base_action_->cancelAllGoals();  //if you want to cancel goal, use this
       vx_ = vy_ = vth_ = 0.0;

--- a/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_robot_hardware.cpp
@@ -248,6 +248,9 @@ namespace robot_hardware
     if(robot_status_.p_stopped_err_){
       ROS_WARN("The robot is protective stopped, please release it.");
     }
+    if(robot_status_.connection_err_ && robot_status_.calib_err_){
+      ROS_WARN("The robot is Emergency stopped, please release it.");
+    }
     return;
   }
 


### PR DESCRIPTION
Currently, if you press the ESTOP button while the robot is moving, the odometry value will be changed even though it is not moving. 
So, in this case, assign the value of 0 to vx,vy,vz used in the odometry calculation .