### PR TITLE
change global planner and modify some params

### DIFF
--- a/seed_r7_navigation/config/TebLocalPlanner.yaml
+++ b/seed_r7_navigation/config/TebLocalPlanner.yaml
@@ -1,4 +1,10 @@
 controller_frequency: 10.0
+#planner_frequency: 0.5
+
+GlobalPlanner:
+  orientation_mode: 1
+  #None=0,Forward=1,Interploalete=2,ForwardThenInterplate=3,
+  #Backward=4,Leftward=5,Rightward=6
 
 TebLocalPlannerROS:
 
@@ -9,7 +15,7 @@ TebLocalPlannerROS:
   teb_autosize: True
   dt_ref: 0.3
   dt_hysteresis: 0.1
-  global_plan_overwrite_orientation: True
+  global_plan_overwrite_orientation: False
   max_global_plan_lookahead_dist: 3.0
   feasibility_check_no_poses: 5
   allow_init_with_backwards_motion: False
@@ -25,8 +31,8 @@ TebLocalPlannerROS:
   min_turning_radius: 0.0
   footprint_model: # types: "point", "circular", "two_circles", "line", "polygon"
     type: "line"
-    line_start: [-0.1, 0.0] # for type "line"
-    line_end: [0.1, 0.0] # for type "line"
+    line_start: [-0.2, 0.0] # for type "line"
+    line_end: [0.2, 0.0] # for type "line"
 
 # GoalTolerance
   xy_goal_tolerance: 0.03
@@ -54,8 +60,8 @@ TebLocalPlannerROS:
   weight_acc_lim_x: 1
   weight_acc_lim_y: 1
   weight_acc_lim_theta: 1
-  weight_kinematics_nh: 100
-  weight_kinematics_forward_drive: 1
+  weight_kinematics_nh: 10
+  weight_kinematics_forward_drive: 1000
   weight_kinematics_turning_radius: 0.1
   weight_optimaltime: 1
   weight_obstacle: 50

--- a/seed_r7_navigation/config/costmap_common.yaml
+++ b/seed_r7_navigation/config/costmap_common.yaml
@@ -17,12 +17,12 @@ static:
     map_topic: /map
     subscribe_to_updates: true
 
-obstacles_laser:
+obstacles:
     observation_sources: laser front_camera rear_camera
     laser: {data_type: LaserScan, clearing: true, marking: true, topic: scan, inf_is_valid: true}
     front_camera: {data_type: LaserScan, clearing: true, marking: true, topic: front_camera_scan, inf_is_valid: true}
     rear_camera: {data_type: LaserScan, clearing: true, marking: true, topic: rear_camera_scan, inf_is_valid: true}
 
 #costmap radius
-inflation:
-    inflation_radius: 0.2
+#inflation:
+#    inflation_radius: 0.2

--- a/seed_r7_navigation/config/costmap_global_laser.yaml
+++ b/seed_r7_navigation/config/costmap_global_laser.yaml
@@ -1,9 +1,8 @@
 global_frame: odom
 rolling_window: true
 track_unknown_space: true
-width=10.0
-height=10.0
+inflation_radius: 0.4
 
 plugins:
-  - {name: obstacles_laser,           type: "costmap_2d::ObstacleLayer"}
-  - {name: inflation,                 type: "costmap_2d::InflationLayer"}
+  - {name: obstacles,   type: "costmap_2d::ObstacleLayer"}
+  - {name: inflation,   type: "costmap_2d::InflationLayer"}

--- a/seed_r7_navigation/config/costmap_global_static.yaml
+++ b/seed_r7_navigation/config/costmap_global_static.yaml
@@ -1,7 +1,9 @@
 global_frame: map
 rolling_window: false
 track_unknown_space: true
+inflation_radius: 0.4
 
 plugins:
-  - {name: static,                  type: "costmap_2d::StaticLayer"}
-  - {name: inflation,               type: "costmap_2d::InflationLayer"}
+  - {name: static,     type: "costmap_2d::StaticLayer"}
+  - {name: obstacles,  type: "costmap_2d::ObstacleLayer"}
+  - {name: inflation,  type: "costmap_2d::InflationLayer"}

--- a/seed_r7_navigation/config/costmap_local.yaml
+++ b/seed_r7_navigation/config/costmap_local.yaml
@@ -2,7 +2,9 @@ global_frame: odom
 rolling_window: true
 width: 6.0
 height: 6.0
+inflation_radius: 0.2
 
 plugins:
-  - {name: obstacles_laser,           type: "costmap_2d::ObstacleLayer"}
-  - {name: inflation,                 type: "costmap_2d::InflationLayer"}
+  - {name: static,     type: "costmap_2d::StaticLayer"}
+  - {name: obstacles,  type: "costmap_2d::ObstacleLayer"}
+  - {name: inflation,  type: "costmap_2d::InflationLayer"}

--- a/seed_r7_navigation/launch/making_map_navigation.launch
+++ b/seed_r7_navigation/launch/making_map_navigation.launch
@@ -4,7 +4,9 @@
   <include file="$(find seed_r7_navigation)/launch/gmapping.launch" />
 
   <!--- Run Move Base -->
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
   <include file="$(find seed_r7_navigation)/launch/move_base.launch">
     <arg name="map_topic" value="map"/>
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)"/>
   </include>
 </launch>

--- a/seed_r7_navigation/launch/move_base.launch
+++ b/seed_r7_navigation/launch/move_base.launch
@@ -23,9 +23,11 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
 <launch>
   <arg name="map_topic" default="map_keepout"/>
   <arg name="no_static_map" default="false"/>
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
 
    <!-- global planner type -->
-  <arg name="base_global_planner" default="navfn/NavfnROS"/>
+  <!-- <arg name="base_global_planner" default="navfn/NavfnROS"/> -->
+  <arg name="base_global_planner" default="global_planner/GlobalPlanner"/>
 
   <!-- local planner option:
        EBandPlannerROS, TrajectoryPlannerROS, DWAPlannerROS -->
@@ -46,6 +48,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCL
   <node pkg="move_base" type="move_base" name="move_base"
         respawn="false" output="screen">
     <remap from="map" to="$(arg map_topic)"/>
+    <remap from="cmd_vel" to="$(arg cmd_vel_topic)"/>
 
     <!-- planner type -->
     <param name="base_global_planner" value="$(arg base_global_planner)"/>

--- a/seed_r7_navigation/launch/static_map_navigation.launch
+++ b/seed_r7_navigation/launch/static_map_navigation.launch
@@ -15,8 +15,10 @@
   <include file="$(find seed_r7_navigation)/launch/amcl.launch" />
 
   <!--- Run Move Base -->
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
   <include file="$(find seed_r7_navigation)/launch/move_base.launch">
     <arg name="costmap_common_config" value="$(arg costmap_common_config)" />
     <arg name="costmap_local_config" value="$(arg costmap_local_config)" />
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)"/>
   </include>
 </launch>

--- a/seed_r7_navigation/launch/wheel_with_dummy.launch
+++ b/seed_r7_navigation/launch/wheel_with_dummy.launch
@@ -7,11 +7,15 @@
   </node>
 
   <!-- Run map navigation -->
-  <arg name="map_keepout_file" default="$(find seed_r7_navigation)/maps/dummy.yaml"/>
-  <arg name="map_localization_file" default="$(find seed_r7_navigation)/maps/dummy.yaml"/>
+  <arg name="map_localization_file"    default="$(find seed_r7_navigation)/maps/dummy.yaml" />
+  <arg name="map_keepout_file"         default="$(arg map_localization_file)"  />
+
+  <!-- Run map navigation -->
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
   <include file="$(find seed_r7_navigation)/launch/static_map_navigation.launch">
-    <arg name="map_keepout_file" value="$(arg map_keepout_file)" />
     <arg name="map_localization_file" value="$(arg map_localization_file)"/>
+    <arg name="map_keepout_file"      value="$(arg map_keepout_file)" />
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)"/>
   </include>
 
 </launch>

--- a/seed_r7_navigation/launch/wheel_with_making_map.launch
+++ b/seed_r7_navigation/launch/wheel_with_making_map.launch
@@ -7,6 +7,9 @@
            file="$(find seed_r7_navigation)/launch/wheel_bringup.launch" />
 
   <!--- Run making map -->
-  <include file="$(find seed_r7_navigation)/launch/making_map_navigation.launch" />
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
+  <include file="$(find seed_r7_navigation)/launch/making_map_navigation.launch">
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)"/>
+  </include>
 
 </launch>

--- a/seed_r7_navigation/launch/wheel_with_static_map.launch
+++ b/seed_r7_navigation/launch/wheel_with_static_map.launch
@@ -11,8 +11,10 @@
   <arg name="map_keepout_file"         default="$(find seed_r7_navigation)/maps/map.yaml" />
 
   <!--- Run Move Base -->
+  <arg name="cmd_vel_topic" default="cmd_vel"/>
   <include file="$(find seed_r7_navigation)/launch/static_map_navigation.launch">
     <arg name="map_localization_file" value="$(arg map_localization_file)"/>
     <arg name="map_keepout_file"      value="$(arg map_keepout_file)" />
+    <arg name="cmd_vel_topic" value="$(arg cmd_vel_topic)"/>
   </include>
 </launch>

--- a/seed_r7_navigation/package.xml
+++ b/seed_r7_navigation/package.xml
@@ -20,6 +20,7 @@
   <depend>gmapping</depend>
   <depend>map_server</depend>
   <depend>teb_local_planner</depend>
+  <depend>global_planner</depend>
   <depend>rospy</depend>
 
 </package>


### PR DESCRIPTION
主な変更点は下記の通り

* global plannerを``NavfnROS``から``GlobalPlanner``に変更    
``teb_local_planner``は``GlobalPlanner``の方が相性が良いため。特にバックの時は顕著。
参考ページ　：　http://wiki.ros.org/teb_local_planner/Tutorials/Frequently%20Asked%20Questions

* 横移動の活用(``TebLocalPlanner.yaml``の`` weight_kinematics_nh:``)    
今までは同値を低くすると斜めに走ることが多かった。
global plannerの変更のおかげか、障害物回避や本当に真横に移動したい時のみ有効に作用する。
横移動させたくない場合は同値を高くすること

* 障害物回避用フットプリントの変更
人のつま先にあたることが多かったので、前後に伸ばした

* ``ObstacleLayer``の名前変更    
``rotate_recovery``時のコストマップをクリアする際のレイヤー名がデフォルトで``obstalcs``のため。    
今までの設定ではクリアされなかった。
参考：https://answers.ros.org/question/252530/static-global-map-updating/    

* inflation値をグローバル``0.4``とローカル``0.2``で差異を設ける    
グローバルプランでは、壁より離れてプランニングして欲しいが、ローカルプランでは、極力狭い場所まで通れるようにしたいため

* グローバルコストマップに``obstacles``を含める    
障害物が出てきた時に、グローバルプランを再計算せずローカルプランで頑張ろうとして、頑張れずにスタックする時があるため。    
もし障害物関係無しに定期的に再計算したい場合は、``TebLocalPlanner.yaml``に記載の``planner_frequency:``を使うこと。

* ローカルコストマップに``static``を含める    
含めないと進入禁止エリアの設定が反映されないため

* ``move_base``の``cmd_vel``をargからremapできるようにする    
下記のような排他的処理を使う際に便利なため
http://wiki.ros.org/twist_mux

