### PR TITLE
reduce communication load & add ResetOdom.srv

### DIFF
--- a/seed_r7_ros_controller/CMakeLists.txt
+++ b/seed_r7_ros_controller/CMakeLists.txt
@@ -50,6 +50,7 @@ add_service_files(
    LedControl.srv
    SetInitialPose.srv
    ResetRobotStatus.srv
+   ResetOdom.srv
 )
 generate_messages(
   DEPENDENCIES

--- a/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_mover_controller.h
+++ b/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_mover_controller.h
@@ -21,6 +21,7 @@
 
 #include "seed_r7_ros_controller/LedControl.h"
 #include "seed_r7_ros_controller/SetInitialPose.h"
+#include "seed_r7_ros_controller/ResetOdom.h"
 
 #define MAX_ACC_X 1.0
 #define MAX_ACC_Y 1.0
@@ -51,6 +52,7 @@ class MoverController
   bool setInitialPoseCallback(seed_r7_ros_controller::SetInitialPose::Request& _req, seed_r7_ros_controller::SetInitialPose::Response& _res); 
   bool ledControlCallback(seed_r7_ros_controller::LedControl::Request& _req, seed_r7_ros_controller::LedControl::Response& _res);
   void moveBaseStatusCallBack(const actionlib_msgs::GoalStatusArray::ConstPtr &status);
+  bool resetOdomCallback(seed_r7_ros_controller::ResetOdom::Request &_req, seed_r7_ros_controller::ResetOdom::Response &_res);
 
   ros::NodeHandle nh_;
   ros::Publisher odom_pub_,initialpose_pub_;
@@ -61,6 +63,7 @@ class MoverController
 
   ros::ServiceServer led_control_server_;
   ros::ServiceServer set_initialpose_server_;
+  ros::ServiceServer reset_odom_server_;
 
 /*
   ros::SubscribeOptions base_ops_;

--- a/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_robot_hardware.h
+++ b/seed_r7_ros_controller/include/seed_r7_ros_controller/seed_r7_robot_hardware.h
@@ -190,6 +190,8 @@ namespace robot_hardware
     ros::Publisher robot_info_pub_;
     seed_r7_ros_controller::RobotInfo robot_info_;
     ros::Subscriber cmd_vel_sub_, odom_sub_;
+    int8_t pre_diag_level_;
+    std::string pre_diag_msg_;
   };
 }
 

--- a/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
+++ b/seed_r7_ros_controller/src/seed_r7_mover_controller.cpp
@@ -51,6 +51,8 @@ robot_hardware::MoverController::MoverController
 
   set_initialpose_server_
     = nh_.advertiseService("set_initialpose", &MoverController::setInitialPoseCallback,this);
+  reset_odom_server_
+    = nh_.advertiseService("reset_odom", &MoverController::resetOdomCallback, this);
 
 }
 
@@ -265,6 +267,16 @@ bool robot_hardware::MoverController::ledControlCallback
   hw_->runLedScript(_req.send_number, _req.script_number);
 
   _res.result = "LED succeeded";
+
+  return true;
+}
+
+bool robot_hardware::MoverController::resetOdomCallback(seed_r7_ros_controller::ResetOdom::Request &_req,
+                                                        seed_r7_ros_controller::ResetOdom::Response &_res)
+{
+  x_ = y_ = th_ = 0;
+
+  _res.result = "ResetOdom succeeded";
 
   return true;
 }

--- a/seed_r7_ros_controller/srv/ResetOdom.srv
+++ b/seed_r7_ros_controller/srv/ResetOdom.srv
@@ -1,0 +1,2 @@
+---
+string result


### PR DESCRIPTION
* reduce communication load
    * in case of diagnostic level is not 0, driver status is checked only once (before: every second)
    * not obtain motor current value during emergency stop, because driver power is off

* add ResetOdom.srv
if you run ``rosservice call /reset_odom``, odometry position is set by (0,0,0)