### PR TITLE
add rear laser

### DIFF
--- a/seed_r7_description/urdf/typeG_wheel/wheels.urdf.xacro
+++ b/seed_r7_description/urdf/typeG_wheel/wheels.urdf.xacro
@@ -162,6 +162,28 @@
     </link>
     <xacro:gazebo_link_reference link_name="wheels_base_laser_link" />
 
+    <link name="wheels_rear_laser_link">
+      <xacro:unless value="${disable_mesh}"> <visual>
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <geometry>
+          <mesh filename="package://seed_r7_description/meshes/typeG_wheel/wheels_urg.dae" scale="1 1 1" />
+        </geometry>
+      </visual> </xacro:unless>
+      <xacro:unless value="${disable_mesh}"> <collision>
+        <origin xyz="0.0 0.0 -0.0124" rpy="0 -0 0"/>
+        <geometry>
+          <box size="0.08 0.1 0.07" />
+        </geometry>
+      </collision> </xacro:unless>
+      <inertial>
+        <mass value="0.2" />
+        <origin xyz="0 0 0" rpy="0 -0 0"/>
+        <inertia ixx="0.0528" ixy="0" ixz="0" iyy="0.0202" iyz="0" izz="0.0235"/>
+      </inertial>
+    </link>
+    <xacro:gazebo_link_reference link_name="wheels_rear_laser_link" />
+
+
     <joint name="base_link_to_wheel_base_link_connector" type="fixed">
       <parent link="${base_link}"/>
       <child link="wheel_base_link"/>
@@ -204,6 +226,12 @@
       <origin xyz="0.308 0 0.1014" rpy="0 0 0"/>
     </joint>
 
+    <joint name="wheels_body_to_rear_laser_connector" type="fixed">
+      <parent  link="wheel_base_link"/>
+      <child link="wheels_rear_laser_link"/>
+      <origin xyz="-0.308 0 0.1014" rpy="0 0 -3.141592"/>
+    </joint>
+
     <link name="front_camera_base_link"/>
     <joint name="wheel_base_link_to_front_camera_base_link" type="fixed">
       <parent  link="wheel_base_link"/>
@@ -215,7 +243,7 @@
     <joint name="front_camera_base_link_to_front_camera_link" type="fixed">
       <parent  link="front_camera_base_link"/>
       <child link="front_camera_link"/>
-      <origin xyz="0 0.0175 0.0125" rpy="0 0 0"/>
+      <origin xyz="0 0.0325 0.0125" rpy="0 0 0"/>
     </joint>
 
     <link name="front_camera_right_ir_frame"/>
@@ -236,7 +264,7 @@
     <joint name="rear_camera_base_link_to_rear_camera_link" type="fixed">
       <parent  link="rear_camera_base_link"/>
       <child link="rear_camera_link"/>
-      <origin xyz="0 0.0175 0.0125" rpy="0 0 0"/>
+      <origin xyz="0 0.0325 0.0125" rpy="0 0 0"/>
     </joint>
 
     <link name="rear_camera_right_ir_frame"/>

--- a/seed_r7_navigation/config/costmap_common.yaml
+++ b/seed_r7_navigation/config/costmap_common.yaml
@@ -18,8 +18,9 @@ static:
     subscribe_to_updates: true
 
 obstacles:
-    observation_sources: laser front_camera rear_camera
+    observation_sources: laser rear_laser front_camera rear_camera
     laser: {data_type: LaserScan, clearing: true, marking: true, topic: scan, inf_is_valid: true}
+    rear_laser: {data_type: LaserScan, clearing: true, marking: true, topic: scan_rear, inf_is_valid: true}
     front_camera: {data_type: LaserScan, clearing: true, marking: true, topic: front_camera_scan, inf_is_valid: true}
     rear_camera: {data_type: LaserScan, clearing: true, marking: true, topic: rear_camera_scan, inf_is_valid: true}
 

--- a/seed_r7_navigation/launch/wheel_bringup.launch
+++ b/seed_r7_navigation/launch/wheel_bringup.launch
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 
 <launch>
+  <arg name="use_rear_laser" default="false" />
 
   <!--  URG Settings -->
   <arg name="~ip_address" default="192.168.0.10" />
@@ -10,10 +11,24 @@
     <param name="~ip_address" value="$(arg ~ip_address)" />
     <param name="~frame_id" value="$(arg ~frame_id)" />
 
-    <!-- +-135[deg] -->     
+    <!-- +-115[deg] -->
     <param name="~angle_min" value="-2.01" />
     <param name="~angle_max" value="2.01" /> 
 
+  </node>
+
+  <!--  URG rear Settings -->
+  <arg name="~ip_address_rear" default="192.168.0.11" />
+  <arg name="~frame_id_rear" default="wheels_rear_laser_link" />
+
+  <node if="$(arg use_rear_laser)" name="urg_node_rear" pkg="urg_node" type="urg_node" >
+    <param name="~ip_address" value="$(arg ~ip_address_rear)" />
+    <param name="~frame_id" value="$(arg ~frame_id_rear)" />
+    <remap from="scan" to="scan_rear"/>
+
+    <!-- +-115[deg] -->
+    <param name="~angle_min" value="-2.01" />
+    <param name="~angle_max" value="2.01" />
   </node>
 
   <!-- DualShock3 Settings -->


### PR DESCRIPTION
* add link/joint settings in urdf file
(incidentally, bug fixed with realsense link)
* add ``rear_laser`` as obstacle observation source in costmap_common file
* add urg_node for rear laser in bringup
if you change the ``use_rear_laser`` value to ``true``, you can use the rear laser